### PR TITLE
Create basic .editorconfig file

### DIFF
--- a/quartz-manager-api/.editorconfig
+++ b/quartz-manager-api/.editorconfig
@@ -1,0 +1,10 @@
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+max_line_length = 120
+tab_width = 4
+ij_continuation_indent_size = 4
+


### PR DESCRIPTION
Java sources have not single code style.
Code intentations are random (2 spaces, 4 spaces, tabs)

This is the first step to create global codestyle.

The `.editorconfig` file format (https://editorconfig.org/) is widely supported by most popular IDEs and fits the best to describe code style.

4 spaces as indentation for java is the most popular indentation style.